### PR TITLE
Updated Jetpack URL

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["Jetpack"]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # Android Jetpack 🚀
-[Android Jetpack](https://developer.android.com/10/?linkId=58619083) REMAKE using [p5js](https://p5js.org) 😁
-
+[Android Jetpack](https://developer.android.com/jetpack) REMAKE using [p5js](https://p5js.org) 😁

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Android Jetpack 🚀
+
 [Android Jetpack](https://developer.android.com/jetpack) REMAKE using [p5js](https://p5js.org) 😁


### PR DESCRIPTION
The Android 10 Jetpack URL (pointing into the documentation) was broken.  This PR uses the updated alias that should work going forward.